### PR TITLE
factorize postfix multi instance directory resolution

### DIFF
--- a/lib/facter/multi_instance_directories.rb
+++ b/lib/facter/multi_instance_directories.rb
@@ -1,0 +1,5 @@
+Facter.add(:postfix_multi_instance_directories) do
+  setcode do
+    Pathname.glob("/etc/postfix-*/main.cf").map { |i| i.dirname }
+  end
+end

--- a/templates/main.cf.erb
+++ b/templates/main.cf.erb
@@ -984,4 +984,4 @@ postscreen_dnsbl_action = <%= @postscreen_dnsbl_action %>
 multi_instance_name = <%= @instance %>
 multi_instance_wrapper = ${command_directory}/postmulti -p --
 multi_instance_enable = yes
-multi_instance_directories = <%= Pathname.glob("/etc/postfix-*/main.cf").map { |i| i.dirname }.join(" ") %>
+multi_instance_directories = <%= @postfix_multi_instance_directories.join(" ") %>


### PR DESCRIPTION
The directory glob didn't work inside the main.cf template so I moved it in a fact.  It was causing the configuration to be changed multiple times which resulted in the postfix service to be restarted on every run.